### PR TITLE
zpy cli create job filter

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -1,5 +1,5 @@
 from cli.config import login, initialize_config, switch_env, read_config
-from cli.datasets import fetch_datasets, fetch_dataset, create_uploaded_dataset, create_generated_dataset
+from cli.datasets import fetch_datasets, fetch_dataset, create_uploaded_dataset, create_generated_dataset, filter_dataset
 from cli.scenes import fetch_scenes, fetch_scene, create_scene
 from cli.jobs import fetch_jobs, create_new_job
 from cli.utils import to_pathlib_path, parse_args
@@ -186,5 +186,5 @@ def create_job(name, operation, datasets, filters, args):
     job_config = parse_args(args)
     datasets_list = [x for x in datasets]
     for dfilter in filters:
-        filter_dataset(dfilter, config['ENDPOINT'], config['TOKEN'])
+        datasets_list.extend(filter_dataset(dfilter, config['ENDPOINT'], config['TOKEN']))
     create_new_job(name, operation, job_config, datasets_list, config['ENDPOINT'], config['TOKEN'])

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -179,9 +179,12 @@ def create_dataset(name, scene, args):
 @click.argument('name')
 @click.argument('operation')
 @click.option('datasets', '-d', multiple=True)
+@click.option('filters', '-f', multiple=True)
 @click.argument('args', nargs=-1)
-def create_job(name, operation, datasets, args):
+def create_job(name, operation, datasets, filters, args):
     config = read_config()
     job_config = parse_args(args)
     datasets_list = [x for x in datasets]
+    for dfilter in filters:
+        filter_dataset(dfilter, config['ENDPOINT'], config['TOKEN'])
     create_new_job(name, operation, job_config, datasets_list, config['ENDPOINT'], config['TOKEN'])

--- a/cli/datasets.py
+++ b/cli/datasets.py
@@ -1,14 +1,10 @@
-from cli.utils import auth_headers, download_url, to_pathlib_path
+from cli.utils import auth_headers, download_url, to_pathlib_path, parse_dataset_filter
 from table_logger import TableLogger
 import requests
 import logging
 import json
 
 log = logging.getLogger(__name__)
-
-
-class FetchFailed(Exception):
-    pass
 
 
 def create_generated_dataset(name, scene_name, config, url, token):
@@ -40,24 +36,25 @@ def create_generated_dataset(name, scene_name, config, url, token):
 def filter_dataset(dfilter, url, token):
     """ filter dataset """
     dset = []
-    dset.extend(filter_generated_dataset(dfilter, url, token))
-    dset.extend(filter_uploaded_dataset(dfilter, url, token))
-    dset.extend(filter_job_dataset(dfilter, url, token))
+    field, pattern, regex = parse_dataset_filter(dfilter)
+    endpoint = f'{endpoint}/api/v1/uploaded-data-sets/'
+    dset.extend(filter_dataset_url(field, pattern, regex, endpoint, token))
+    endpoint = f'{endpoint}/api/v1/generated-data-sets/'
+    dset.extend(filter_dataset_url(field, pattern, regex, endpoint, token))
+    endpoint = f'{endpoint}/api/v1/job-data-sets/'
+    dset.extend(filter_dataset_url(field, pattern, regex, endpoint, token))
     return dset
 
-def filter_generated_dataset(dfilter, url, token):
+
+def filter_dataset_url(field, pattern, regex, url, token):
     """ filter generated dataset """
-    asdfasdf
-
-
-def filter_uploaded_dataset(dfilter, url, token):
-    """ filter uploaded dataset """
-    asfasdfa
-
-
-def filter_job_dataset(dfilter, url, token):
-    """ filter job dataset """
-    asdfasdf
+    endpoint = f'{url}/
+    r = requests.post(endpoint, headers=auth_headers(token))
+    if r.status_code != 200:
+        log.warning(f"Unable to filter {url}")
+        return []
+    response = json.loads(r.text)
+    return [x.id for x in response]
 
 
 def create_uploaded_dataset(name, path, url, token):

--- a/cli/datasets.py
+++ b/cli/datasets.py
@@ -37,24 +37,30 @@ def filter_dataset(dfilter, url, token):
     """ filter dataset """
     dset = []
     field, pattern, regex = parse_dataset_filter(dfilter)
-    endpoint = f'{endpoint}/api/v1/uploaded-data-sets/'
+    endpoint = f'{url}/api/v1/uploaded-data-sets/'
     dset.extend(filter_dataset_url(field, pattern, regex, endpoint, token))
-    endpoint = f'{endpoint}/api/v1/generated-data-sets/'
+    endpoint = f'{url}/api/v1/generated-data-sets/'
     dset.extend(filter_dataset_url(field, pattern, regex, endpoint, token))
-    endpoint = f'{endpoint}/api/v1/job-data-sets/'
-    dset.extend(filter_dataset_url(field, pattern, regex, endpoint, token))
+    # TODO figure out a way to have the user ask which set to query
+    #endpoint = f'{url}/api/v1/job-data-sets/'
+    #dset.extend(filter_dataset_url(field, pattern, regex, endpoint, token))
     return dset
 
 
 def filter_dataset_url(field, pattern, regex, url, token):
     """ filter generated dataset """
-    endpoint = f'{url}/
-    r = requests.post(endpoint, headers=auth_headers(token))
+    endpoint = f'{url}?{field}__{pattern}={regex}'
+    r = requests.get(endpoint, headers=auth_headers(token))
     if r.status_code != 200:
         log.warning(f"Unable to filter {url}")
         return []
     response = json.loads(r.text)
-    return [x.id for x in response]
+    datasets, names = [], []
+    for d in response['results']:
+        names.append(d['name'])
+        datasets.append(d['id'])
+    log.info(f'filter <{endpoint}> found {names}')
+    return datasets
 
 
 def create_uploaded_dataset(name, path, url, token):

--- a/cli/datasets.py
+++ b/cli/datasets.py
@@ -35,7 +35,30 @@ def create_generated_dataset(name, scene_name, config, url, token):
         log.warning(f'Unable to create dataset {name} for scene {scene_name} with config {config}')
         return
     log.info(f'created dataset {name} for scene {scene_name} with config {config}')
-    
+
+
+def filter_dataset(dfilter, url, token):
+    """ filter dataset """
+    dset = []
+    dset.extend(filter_generated_dataset(dfilter, url, token))
+    dset.extend(filter_uploaded_dataset(dfilter, url, token))
+    dset.extend(filter_job_dataset(dfilter, url, token))
+    return dset
+
+def filter_generated_dataset(dfilter, url, token):
+    """ filter generated dataset """
+    asdfasdf
+
+
+def filter_uploaded_dataset(dfilter, url, token):
+    """ filter uploaded dataset """
+    asfasdfa
+
+
+def filter_job_dataset(dfilter, url, token):
+    """ filter job dataset """
+    asdfasdf
+
 
 def create_uploaded_dataset(name, path, url, token):
     """ uploaded a dataset to ragnarok """

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -10,6 +10,17 @@ import random
 log = logging.getLogger(__name__)
 
 
+def parse_dataset_filter(dfilter):
+    """ parse a dataset filter string """
+    dfilter_arr = dfilter.split(':')
+    field, pattern, regex = 'name', 'startswith', dfilter_arr[-1]
+    if len(dfilter_arr) == 2:
+        pattern = dfilter_arr[0]
+    elif len(dfilter_arr) == 3:
+        field, pattern = dfilter_arr[0], dfilter_arr[1]
+    return field, pattern, regex
+
+
 def _safe_eval(key):
     try:
         return eval(key)


### PR DESCRIPTION
- when creating a job through the cli can now pass a filter instead of id's
- eg `-f test` will search for datasets whose name starts with test
- more advanced usage `-f blender_version:icontains:2.9` will search for blender_version which contain 2.9