### PR TITLE
New render device function to handle all compute layouts

### DIFF
--- a/zpy/blender.py
+++ b/zpy/blender.py
@@ -45,14 +45,11 @@ def use_gpu(device_type='CUDA', use_cpus=True) -> None:
 
 def use_render_devices(compute_device_type='CUDA', use_cpu=True) -> None:
     """ Choose the rendering devices for rendering. Possible compute devices are NONE,CUDA,OPTIX,OPENCL  
-        Hybrid render device options (GPU+CPU) are possible for CUDA and OPTIX"""
-    log = logging.getLogger(__name__)
+        The hybrid render device options (GPU+CPU) are possible for CUDA and OPTIX"""
     C=bpy.context
     preferences = bpy.context.preferences
     cycles_preferences = preferences.addons["cycles"].preferences
-    compute_devices = []
-    for d in cycles_preferences.get_device_types(C):
-        compute_devices.append(d[0])
+    compute_devices=[d[0] for d in C.preferences.addons['cycles'].preferences.get_device_types(C) ]
     if compute_device_type not in compute_devices:
         raise RuntimeError("Non-existing device type")
     else:

--- a/zpy/blender.py
+++ b/zpy/blender.py
@@ -47,9 +47,12 @@ def use_render_devices(compute_device_type='CUDA', use_cpu=True) -> None:
     """ Choose the rendering devices for rendering. Possible compute devices are NONE,CUDA,OPTIX,OPENCL  
         Hybrid render device options (GPU+CPU) are possible for CUDA and OPTIX"""
     log = logging.getLogger(__name__)
+    C=bpy.context
     preferences = bpy.context.preferences
     cycles_preferences = preferences.addons["cycles"].preferences
-    compute_devices = ['NONE', 'CUDA', 'OPTIX', 'OPENCL']
+    compute_devices = []
+    for d in cycles_preferences.get_device_types(C):
+        compute_devices.append(d[0])
     if compute_device_type not in compute_devices:
         raise RuntimeError("Non-existing device type")
     else:

--- a/zpy/blender.py
+++ b/zpy/blender.py
@@ -43,6 +43,26 @@ def use_gpu(device_type='CUDA', use_cpus=True) -> None:
     log.info(f'using devices {devices}')
 
 
+def use_render_devices(compute_device_type='CUDA', use_cpu=True) -> None:
+    """ Choose the rendering devices for rendering. Possible compute devices are NONE,CUDA,OPTIX,OPENCL  
+        Hybrid render device options (GPU+CPU) are possible for CUDA and OPTIX"""
+    log = logging.getLogger(__name__)
+    preferences = bpy.context.preferences
+    cycles_preferences = preferences.addons["cycles"].preferences
+    compute_devices = ['NONE', 'CUDA', 'OPTIX', 'OPENCL']
+    if compute_device_type not in compute_devices:
+        raise RuntimeError("Non-existing device type")
+    else:
+        cycles_preferences.compute_device_type = compute_device_type
+        devices = cycles_preferences.get_devices_for_type(compute_device_type)
+        if len(devices) > 0:
+            for c in devices:
+                c.use = True
+                if c.type == 'CPU':
+                    c.use = use_cpu
+                log.info(f'using devices {c} {c.type} {c.use}')
+
+
 @gin.configurable
 def set_seed(seed: int = 0) -> None:
     """ Set the random seed. """


### PR DESCRIPTION
current use_gpu function makes some assumptions about the render devices and it does not include the OPTIX core. This new function adds a way to pick all possible options with current Blender